### PR TITLE
Guard against empty OPML content in extract_rss_urls_from_opml

### DIFF
--- a/tools/opml2feeds.py
+++ b/tools/opml2feeds.py
@@ -41,6 +41,8 @@ def extract_rss_urls_from_opml(opml_content):
     :param opml_content: OPML content as a string.
     :return: List of RSS feed URLs.
     """
+    if not opml_content or not opml_content.strip():
+        return []
     try:
         root = ET.fromstring(opml_content)
         rss_urls = set()  # Use a set to avoid duplicates


### PR DESCRIPTION
### FabGPT — code quality

**File:** `tools/opml2feeds.py`

**Rationale:** The function `extract_rss_urls_from_opml` calls `ET.fromstring(opml_content)` without checking if `opml_content` is empty or whitespace-only. If `opml_content` is empty (e.g., due to a 200 OK response with empty body from `fetch_opml_from_url`, or an empty file from `fetch_opml_from_file`), `ET.fromstring('')` raises `ET.ParseError: no element found: line 1, column 0`, which is caught and re-raised — but this is a preventable edge case that can be handled more gracefully by returning an empty list early, avoiding unnecessary parsing and logging overhead.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `f65f6f94f66876af` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"f65f6f94f66876af","source":"quality","model":"qwen3-coder-next","severity":"INFO","iterations":1,"inference_s":6.8,"prompt_sha":"b0cfe6ff584d5481","triage":"INFO"} -->