### PR TITLE
Fix path traversal vulnerability in _serve_xml_file

### DIFF
--- a/server.py
+++ b/server.py
@@ -35,7 +35,10 @@ class CustomXMLHandler(SimpleHTTPRequestHandler):
         requested = (STATIC_DIR / self.path.lstrip('/')).resolve()
         static_root = STATIC_DIR.resolve()
 
-        if not str(requested).startswith(str(static_root)):
+        # Ensure requested path is strictly inside static_root
+        try:
+            requested.relative_to(static_root)
+        except ValueError:
             self.send_error(403, "Forbidden")
             server_logger.warning("Path traversal attempt blocked: %s", self.path)
             return


### PR DESCRIPTION
### FabGPT — code quality

**File:** `server.py`

**Rationale:** The current path traversal check uses `str(requested).startswith(str(static_root))`, but `Path.resolve()` normalizes symlinks and may resolve to a different path than expected. If `STATIC_DIR` is a symlink or contains symlinks, an attacker could craft a path that resolves to a parent directory outside `STATIC_DIR` but still passes the string prefix check. This is a real defect because the code explicitly attempts to guard against path traversal but does so incorrectly — the check is insufficient to prevent directory escapes in symlinked environments.

_Proposed by FabGPT OS and approved by a human before opening._

---
🤖 **FabGPT OS** · source `quality` · model `qwen3-coder-next` · task `51d1adebd7feb989` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"51d1adebd7feb989","source":"quality","model":"qwen3-coder-next","severity":"WARN","iterations":2,"inference_s":14.07,"prompt_sha":"9ba6a2e2611b1198","triage":"WARN"} -->